### PR TITLE
SsmlOutputSpeech is not Public

### DIFF
--- a/Shared/Models/Responses/SsmlOutputSpeech.cs
+++ b/Shared/Models/Responses/SsmlOutputSpeech.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Slight.Alexa.Framework.Models.Responses
 {
-    class SsmlOutputSpeech : IOutputSpeech
+    public class SsmlOutputSpeech : IOutputSpeech
     {
         /// <summary>
         /// A string containing the type of output speech to render. Valid types are:


### PR DESCRIPTION
Attempting to create an Ssml based response fails because ssmlOutputSpeech is a private class.