### PR TITLE
made the SsmlOutputSpeech type public

### DIFF
--- a/Shared/Models/Responses/SsmlOutputSpeech.cs
+++ b/Shared/Models/Responses/SsmlOutputSpeech.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Slight.Alexa.Framework.Models.Responses
 {
-    class SsmlOutputSpeech : IOutputSpeech
+    public class SsmlOutputSpeech : IOutputSpeech
     {
         /// <summary>
         /// A string containing the type of output speech to render. Valid types are:

--- a/Slight.Alexa.Framework.Tests/ModelTests/Examples/SsmlResponse.json
+++ b/Slight.Alexa.Framework.Tests/ModelTests/Examples/SsmlResponse.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": "1.0",
+  "sessionAttributes": {
+    "supportedHoriscopePeriods": {
+      "daily": true,
+      "weekly": false,
+      "monthly": false
+    }
+  },
+  "response": {
+    "outputSpeech": {
+      "type": "SSML",
+      "ssml": "<speak>Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless. Can I help you with anything else?</speak>"
+    },
+    "card": {
+      "type": "Simple",
+      "title": "Horoscope",
+      "content": "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless."
+    },
+    "shouldEndSession": false
+  }
+}

--- a/Slight.Alexa.Framework.Tests/ModelTests/ResponseTests.cs
+++ b/Slight.Alexa.Framework.Tests/ModelTests/ResponseTests.cs
@@ -62,5 +62,53 @@ namespace Slight.Alexa.Framework.Tests.ModelTests
 
             Assert.Equal(workingJson, json);
         }
+
+        [Fact]
+        public void Should_create_same_ssml_json_response_as_example()
+        {
+            var skillResponse = new SkillResponse
+            {
+                Version = "1.0",
+                SessionAttributes = new Dictionary<string, object>
+                {
+                    {
+                        "supportedHoriscopePeriods", new
+                        {
+                            daily = true,
+                            weekly = false,
+                            monthly = false
+                        }
+                    }
+                },
+                Response = new Response
+                {
+                    OutputSpeech = new SsmlOutputSpeech
+                    {
+                        Ssml =
+                            "<speak>Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless. Can I help you with anything else?</speak>"
+                    },
+                    Card = new SimpleCard
+                    {
+                        Title = "Horoscope",
+                        Content =
+                            "Today will provide you a new learning opportunity. Stick with it and the possibilities will be endless."
+                    },
+                    ShouldEndSession = false
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(skillResponse, Formatting.Indented, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            const string example = "SsmlResponse.json";
+            var workingJson = File.ReadAllText(Path.Combine(ExamplesPath, example));
+
+            workingJson = Regex.Replace(workingJson, @"\s", "");
+            json = Regex.Replace(json, @"\s", "");
+
+            Assert.Equal(workingJson, json);
+        }
     }
 }

--- a/Slight.Alexa.Framework.Tests/Slight.Alexa.Framework.Tests.csproj
+++ b/Slight.Alexa.Framework.Tests/Slight.Alexa.Framework.Tests.csproj
@@ -87,6 +87,9 @@
     <None Include="ModelTests\Examples\LaunchRequest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="ModelTests\Examples\SsmlResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="ModelTests\Examples\Response.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
I was porting a Python-written skill, which used some SSML responses, to C#. Found this marvellous package but it didn't seem to support SSML responses. Forked it and there it was, but it was internal.